### PR TITLE
merge fix_table_parse into main

### DIFF
--- a/src/Helper/EmgHelper.php
+++ b/src/Helper/EmgHelper.php
@@ -18,11 +18,11 @@ class EmgHelper
 
     public static function getTableNameByClassName(string $className, bool $plural = true): string
     {
-		if ($plural) {
-			return Str::plural(Str::snake($className));
-		} else {
-			return Str::singular(Str::snake($className));
-		}
+        if ($plural) {
+            return Str::plural(Str::snake($className));
+        } else {
+            return Str::singular(Str::snake($className));
+        }
     }
 
     public static function getClassNameByTableName(string $tableName): string

--- a/src/Helper/EmgHelper.php
+++ b/src/Helper/EmgHelper.php
@@ -16,9 +16,13 @@ class EmgHelper
         return end($pieces);
     }
 
-    public static function getTableNameByClassName(string $className): string
+    public static function getTableNameByClassName(string $className, bool $plural = true): string
     {
-        return Str::plural(Str::snake($className));
+		if ($plural) {
+			return Str::plural(Str::snake($className));
+		} else {
+			return Str::singular(Str::snake($className));
+		}
     }
 
     public static function getClassNameByTableName(string $tableName): string

--- a/src/Processor/TableNameProcessor.php
+++ b/src/Processor/TableNameProcessor.php
@@ -19,8 +19,8 @@ class TableNameProcessor implements ProcessorInterface
 
     public function process(EloquentModel $model, Config $config): void
     {
-		$plural = true;
-		
+        $plural = true;
+        
         $className = $config->getClassName();
         $baseClassName = $config->getBaseClassName();
         $tableName = $config->getTableName() ?: EmgHelper::getTableNameByClassName($className, $plural);
@@ -28,14 +28,14 @@ class TableNameProcessor implements ProcessorInterface
         $schemaManager = $this->databaseManager->connection($config->getConnection())->getDoctrineSchemaManager();
         $prefixedTableName = Prefix::add($tableName);
         if (!$schemaManager->tablesExist($prefixedTableName)) {
-			$plural = false;
-			
-			$tableName = $config->getTableName() ?: EmgHelper::getTableNameByClassName($className, $plural);
-			$prefixedTableName = Prefix::add($tableName);
-			
-			if (!$schemaManager->tablesExist($prefixedTableName)) {
-				throw new GeneratorException(sprintf('Table %s does not exist', $prefixedTableName));
-			}
+            $plural = false;
+            
+            $tableName = $config->getTableName() ?: EmgHelper::getTableNameByClassName($className, $plural);
+            $prefixedTableName = Prefix::add($tableName);
+            
+            if (!$schemaManager->tablesExist($prefixedTableName)) {
+                throw new GeneratorException(sprintf('Table %s does not exist', $prefixedTableName));
+            }
         }
 
         $model


### PR DESCRIPTION
- Allow table names to be singular in the database
- Altered EmgHelper::getTableNameByClassName to output singular or plural table name.